### PR TITLE
Use the Path type rather than raw strings

### DIFF
--- a/settings-parser/src/main.rs
+++ b/settings-parser/src/main.rs
@@ -5,8 +5,7 @@ mod settings_master;
 mod xml_parsing;
 mod to_witcher_script;
 
-use std::path::PathBuf;
-use std::{fs::OpenOptions, io::{Read, Write}, path::Path};
+use std::{fs::OpenOptions, io::{Read, Write}, path::{Path, PathBuf}};
 
 use clap::Parser;
 use to_witcher_script::ToWitcherScript;


### PR DESCRIPTION
Hello,

This goal of this PR is to avoid using raw strings and use `std::path::Path` whenever possible. The use of the Path type offers useful methods such as `path.with_extension("ws")` which allows us to simplify the part where we transform the input path in an output `.ws` file.

I also took the opportunity to replace a few `.clone()` calls to avoid unnecessary allocations with references